### PR TITLE
Add CLAUDE.md AI development guide and enhance README.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,20 +70,21 @@ SalesforceMobileSDK-iOS-Specs/
 │   │   └── SalesforceHybridSDK.podspec
 │   └── ...
 │
-├── SalesforceReact/              # React Native specs
-│   ├── 13.2.0/
-│   │   └── SalesforceReact.podspec
-│   └── ...
-│
 ├── SalesforceFileLogger/         # File logger specs
 │   ├── 13.2.0/
 │   │   └── SalesforceFileLogger.podspec
 │   └── ...
 │
 ├── AgentforceSDK/                # Agentforce SDK specs
-├── SalesforceSwiftSDK/           # Swift SDK specs
-├── FMDB/                         # FMDB (SQLite wrapper) specs
-├── cmark_gfm/                    # Markdown parser specs
+├── AgentforceService/            # Agentforce Service specs
+├── cmark_gfm/                    # Markdown parser specs (Agentforce dependency)
+├── swift-markdown-ui/            # Swift markdown UI specs (Agentforce dependency)
+├── NetworkImage/                 # Network image specs (Agentforce dependency)
+├── SalesforceCache/              # Cache specs (Agentforce dependency)
+├── SalesforceLogging/            # Logging specs (Agentforce dependency)
+├── SalesforceNavigation/         # Navigation specs (Agentforce dependency)
+├── SalesforceNetwork/            # Network specs (Agentforce dependency)
+├── SalesforceUser/               # User specs (Agentforce dependency)
 └── update.sh                     # Helper script to update specs
 ```
 
@@ -182,15 +183,6 @@ git push origin master
 ```
 6. **Consumers Update**: Apps run `pod update` to get new version
 
-### CocoaPods Trunk (Optional)
-
-Some pods may also be published to CocoaPods Trunk (central repository):
-```bash
-pod trunk push MobileSync.podspec
-```
-
-This makes them available without specifying a custom source in Podfile.
-
 ## Podspec Validation
 
 Before publishing, podspecs should be validated:
@@ -206,7 +198,9 @@ pod spec lint MobileSync/13.2.0/MobileSync.podspec \
 
 ## Libraries Distributed
 
-All iOS SDK libraries are available via this specs repo:
+iOS SDK libraries available via this specs repo:
+
+### Core Mobile SDK Libraries
 
 | Library | Purpose |
 |---------|---------|
@@ -216,10 +210,22 @@ All iOS SDK libraries are available via this specs repo:
 | **SmartStore** | Encrypted SQLite storage (SQLCipher) |
 | **MobileSync** | Data synchronization framework |
 | **SalesforceHybridSDK** | Cordova hybrid app support |
-| **SalesforceReact** | React Native bridge |
 | **SalesforceFileLogger** | File-based logging |
+
+### Agentforce Libraries
+
+| Library | Purpose |
+|---------|---------|
 | **AgentforceSDK** | Agentforce agent functionality |
-| **SalesforceSwiftSDK** | Modern Swift SDK layer |
+| **AgentforceService** | Agentforce service layer |
+| **cmark_gfm** | Markdown parser (dependency) |
+| **swift-markdown-ui** | Swift markdown UI (dependency) |
+| **NetworkImage** | Network image loading (dependency) |
+| **SalesforceCache** | Caching utilities (dependency) |
+| **SalesforceLogging** | Logging framework (dependency) |
+| **SalesforceNavigation** | Navigation utilities (dependency) |
+| **SalesforceNetwork** | Network layer (dependency) |
+| **SalesforceUser** | User management (dependency) |
 
 ## Development Workflow
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,346 @@
+# CLAUDE.md — Salesforce Mobile SDK for iOS - CocoaPods Specs Repository
+
+---
+
+## About This Project
+
+The Salesforce Mobile SDK for iOS Specs repository is a **CocoaPods Specs Repository** containing podspec files for all versions of the iOS Mobile SDK libraries. It serves as the distribution mechanism for CocoaPods dependency management.
+
+**Key constraint**: This is a **public specs repository** that enables CocoaPods to resolve and install iOS SDK dependencies. Every podspec published here must be valid, tested, and match the corresponding SDK release.
+
+## Repository Role in SDK Architecture
+
+This repository is the **CocoaPods distribution layer**:
+
+```
+SalesforceMobileSDK-iOS (source code)
+  ├── Podspec files (at repo root)
+  └── Libraries (libs/)
+           │
+           ▼
+    release/release.js
+    (copies podspecs)
+           │
+           ▼
+SalesforceMobileSDK-iOS-Specs (this repo)
+  ├── Library folders with version subdirectories
+  └── update.sh (helper script)
+           │
+           ▼
+    CocoaPods (pod install)
+           │
+           ▼
+    iOS Apps and Templates
+    (consume SDK via Podfile)
+```
+
+## Repository Structure
+
+```
+SalesforceMobileSDK-iOS-Specs/
+├── SalesforceAnalytics/          # Analytics library specs
+│   ├── 13.2.0/
+│   │   └── SalesforceAnalytics.podspec
+│   ├── 13.1.0/
+│   │   └── SalesforceAnalytics.podspec
+│   └── ...
+│
+├── SalesforceSDKCommon/          # Common utilities specs
+│   ├── 13.2.0/
+│   │   └── SalesforceSDKCommon.podspec
+│   └── ...
+│
+├── SalesforceSDKCore/            # Core SDK specs
+│   ├── 13.2.0/
+│   │   └── SalesforceSDKCore.podspec
+│   └── ...
+│
+├── SmartStore/                   # SmartStore specs
+│   ├── 13.2.0/
+│   │   └── SmartStore.podspec
+│   └── ...
+│
+├── MobileSync/                   # MobileSync specs
+│   ├── 13.2.0/
+│   │   └── MobileSync.podspec
+│   └── ...
+│
+├── SalesforceHybridSDK/          # Hybrid SDK specs
+│   ├── 13.2.0/
+│   │   └── SalesforceHybridSDK.podspec
+│   └── ...
+│
+├── SalesforceReact/              # React Native specs
+│   ├── 13.2.0/
+│   │   └── SalesforceReact.podspec
+│   └── ...
+│
+├── SalesforceFileLogger/         # File logger specs
+│   ├── 13.2.0/
+│   │   └── SalesforceFileLogger.podspec
+│   └── ...
+│
+├── AgentforceSDK/                # Agentforce SDK specs
+├── SalesforceSwiftSDK/           # Swift SDK specs
+├── FMDB/                         # FMDB (SQLite wrapper) specs
+├── cmark_gfm/                    # Markdown parser specs
+└── update.sh                     # Helper script to update specs
+```
+
+## How CocoaPods Uses This Repo
+
+### As a Specs Source
+
+Apps and templates reference this repo in their Podfile:
+
+```ruby
+source 'https://cdn.cocoapods.org/'  # Official CocoaPods specs
+source 'https://github.com/forcedotcom/SalesforceMobileSDK-iOS-Specs.git'  # SDK specs
+
+target 'MyApp' do
+  use_frameworks!
+  pod 'MobileSync', '~> 13.2.0'
+end
+```
+
+When `pod install` runs:
+1. CocoaPods clones this specs repo (if not already cached)
+2. Searches for `MobileSync/13.2.0/MobileSync.podspec`
+3. Reads the podspec to determine dependencies and source locations
+4. Downloads and integrates the SDK libraries
+
+### Podspec Structure
+
+Each podspec file defines:
+
+```ruby
+Pod::Spec.new do |s|
+  s.name         = "MobileSync"
+  s.version      = "13.2.0"
+  s.summary      = "Salesforce Mobile SDK for iOS - MobileSync"
+  s.homepage     = "https://github.com/forcedotcom/SalesforceMobileSDK-iOS"
+  s.license      = { :type => "Salesforce.com Mobile SDK License" }
+  s.author       = { "Wolfgang Mathurin" => "wmathurin@salesforce.com" }
+
+  s.platform     = :ios, "17.0"
+  s.source       = { :git => "https://github.com/forcedotcom/SalesforceMobileSDK-iOS.git",
+                     :tag => "v#{s.version}",
+                     :submodules => false }
+
+  s.dependency 'SmartStore', "~>#{s.version}"
+
+  s.source_files = 'libs/MobileSync/MobileSync/Classes/**/*.{h,m,swift}'
+  s.public_header_files = 'libs/MobileSync/MobileSync/Classes/**/*.h'
+  s.resource_bundles = { 'MobileSync' => ['libs/MobileSync/MobileSync/Resources/**'] }
+
+  s.requires_arc = true
+end
+```
+
+## Update Process
+
+### The `update.sh` Script
+
+This script helps copy podspecs from the iOS repo during release:
+
+**Usage**:
+```bash
+./update.sh -b <branch> -v <version>
+
+# Example:
+./update.sh -b v13.2.0 -v 13.2.0
+```
+
+**What it does**:
+1. Clones `SalesforceMobileSDK-iOS` at specified branch/tag
+2. Copies podspec files from iOS repo root
+3. Creates version subdirectories in this repo
+4. Places podspecs in appropriate locations
+
+**Example**:
+```bash
+# From iOS repo root:
+MobileSync.podspec
+
+# Copied to Specs repo:
+MobileSync/13.2.0/MobileSync.podspec
+```
+
+### Manual Release Process
+
+The typical workflow for publishing a new SDK version:
+
+1. **In iOS Repo**: Create and test podspecs at repo root
+2. **Tag iOS Repo**: `git tag v13.2.0`
+3. **Run update.sh**: In this repo, run `./update.sh -b v13.2.0 -v 13.2.0`
+4. **Verify**: Check that podspecs are in correct version directories
+5. **Commit and Push**:
+```bash
+git add .
+git commit -m "Release v13.2.0"
+git push origin master
+```
+6. **Consumers Update**: Apps run `pod update` to get new version
+
+### CocoaPods Trunk (Optional)
+
+Some pods may also be published to CocoaPods Trunk (central repository):
+```bash
+pod trunk push MobileSync.podspec
+```
+
+This makes them available without specifying a custom source in Podfile.
+
+## Podspec Validation
+
+Before publishing, podspecs should be validated:
+
+```bash
+# Lint a specific podspec
+pod spec lint MobileSync/13.2.0/MobileSync.podspec
+
+# Lint with dependencies
+pod spec lint MobileSync/13.2.0/MobileSync.podspec \
+  --sources='https://github.com/forcedotcom/SalesforceMobileSDK-iOS-Specs.git,https://cdn.cocoapods.org/'
+```
+
+## Libraries Distributed
+
+All iOS SDK libraries are available via this specs repo:
+
+| Library | Purpose |
+|---------|---------|
+| **SalesforceSDKCommon** | Shared utilities, crypto, base protocols |
+| **SalesforceAnalytics** | Telemetry and event tracking |
+| **SalesforceSDKCore** | OAuth, REST API, account management, push notifications |
+| **SmartStore** | Encrypted SQLite storage (SQLCipher) |
+| **MobileSync** | Data synchronization framework |
+| **SalesforceHybridSDK** | Cordova hybrid app support |
+| **SalesforceReact** | React Native bridge |
+| **SalesforceFileLogger** | File-based logging |
+| **AgentforceSDK** | Agentforce agent functionality |
+| **SalesforceSwiftSDK** | Modern Swift SDK layer |
+
+## Development Workflow
+
+### Normal Development (Not This Repo)
+
+**Important**: You typically **do not** make changes directly in this repo except during releases.
+
+**For SDK development**:
+1. Make changes in `SalesforceMobileSDK-iOS` repository
+2. Update podspecs in iOS repo root
+3. Test locally: `pod install --project-directory=<app>`
+4. During release: Use `update.sh` to copy podspecs here
+
+### Testing Podspecs Locally
+
+Before releasing, test podspecs locally:
+
+```bash
+# In an app's Podfile, use local path
+pod 'MobileSync', :path => '/path/to/SalesforceMobileSDK-iOS'
+
+# Or use local specs repo
+pod 'MobileSync', :podspec => '/path/to/SalesforceMobileSDK-iOS-Specs/MobileSync/13.2.0/MobileSync.podspec'
+```
+
+### Fixing Published Podspecs
+
+If a podspec has issues after publishing:
+
+**Preferred**: Publish a patch version (e.g., 13.2.1)
+- Update iOS repo
+- Create new tag
+- Run update.sh with new version
+- Publish new version
+
+**Last Resort**: Modify existing podspec (not recommended)
+- Only for critical bugs
+- Requires all users to clear CocoaPods cache
+- Document in release notes
+
+## Code Standards
+
+Since this is primarily a distribution repo:
+
+### Podspec Quality
+- **Valid Ruby**: Ensure proper Ruby syntax
+- **Complete metadata**: Author, license, homepage all filled
+- **Correct dependencies**: All pod dependencies specified with versions
+- **Source accuracy**: Git tag matches version
+- **Platform requirements**: Minimum iOS version specified
+- **File paths**: Source files and headers correctly specified
+
+### Version Consistency
+- **All libraries**: Same version number across all SDK libraries (e.g., all 13.2.0)
+- **Tag format**: Use `v<version>` format (e.g., `v13.2.0`)
+- **Semantic versioning**: Follow semver (major.minor.patch)
+
+## Code Review Checklist
+
+When reviewing changes (typically during release):
+
+- [ ] **Version consistency**: All SDK libraries have same version
+- [ ] **Podspec validity**: Run `pod spec lint` on all changed podspecs
+- [ ] **Git tags exist**: Source tags exist in iOS repo
+- [ ] **Dependency versions**: Pod dependencies reference correct versions
+- [ ] **File paths**: Source files and resources paths are correct
+- [ ] **No breaking changes**: Unless major version bump
+- [ ] **Release notes**: Document changes for this version
+- [ ] **Testing**: Podspecs tested in sample app before publishing
+
+## Agent Behavior Guidelines
+
+### Do
+- Understand this is a distribution repository
+- Direct SDK code changes to `SalesforceMobileSDK-iOS` repo
+- Help validate podspec syntax and structure
+- Verify version consistency across libraries
+- Test podspecs locally before committing
+
+### Don't
+- Don't make SDK code changes here (wrong repo)
+- Don't publish without human approval
+- Don't modify existing published podspecs without discussion
+- Don't change version numbers manually (should match iOS repo tags)
+- Don't skip validation (`pod spec lint`)
+
+### Escalation — Stop and Flag for Human Review
+- Any publication of new podspecs (release event)
+- Modification of existing published podspecs
+- Changes to dependency versions
+- New libraries added to specs repo
+- Breaking changes in podspecs
+- CocoaPods Trunk publication
+
+## Key Domain Concepts
+
+- **CocoaPods**: Dependency manager for iOS projects (like npm for Node.js)
+- **Podspec**: Ruby file describing a library (name, version, source, dependencies)
+- **Specs Repo**: Git repository containing podspecs for CocoaPods to query
+- **Pod**: A library distributed via CocoaPods
+- **Podfile**: Manifest file in iOS projects listing pod dependencies
+- **Pod Install**: Command that resolves and installs dependencies
+- **Source**: URL of specs repo (can have multiple sources)
+- **Subspecs**: Optional sub-libraries within a pod
+
+## Version History
+
+Version numbers follow the iOS SDK release cycle:
+
+| Version | Release Date | Notes |
+|---------|-------------|-------|
+| 13.2.0  | Latest      | Current stable |
+| 13.1.0  | -           | Previous release |
+| 13.0.0  | -           | Major release |
+
+See [iOS repo release notes](https://github.com/forcedotcom/SalesforceMobileSDK-iOS/releases) for detailed version history.
+
+## Related Documentation
+
+- **iOS SDK**: See `SalesforceMobileSDK-iOS/CLAUDE.md` for SDK development
+- **CocoaPods Guides**: https://guides.cocoapods.org/
+- **Podspec Syntax**: https://guides.cocoapods.org/syntax/podspec.html
+- **iOS-SPM**: See `SalesforceMobileSDK-iOS-SPM/CLAUDE.md` for Swift Package Manager distribution
+- **Mobile SDK Developer Guide**: https://developer.salesforce.com/docs/platform/mobile-sdk/guide

--- a/README.md
+++ b/README.md
@@ -1,3 +1,161 @@
 ![Build Status](https://forcedotcom.github.io/SalesforceMobileSDK-TestResults/Specs-results/master/latest/buildstatus.svg)
 
-# SalesforceMobileSDK-iOS-Specs
+# Salesforce Mobile SDK for iOS - CocoaPods Specs Repository
+
+CocoaPods podspec repository for the Salesforce Mobile SDK for iOS.
+
+## Overview
+
+This repository contains [CocoaPods](https://cocoapods.org/) podspec files for all versions of the Salesforce Mobile SDK for iOS. It serves as a **specs source** that enables CocoaPods to resolve and install iOS SDK dependencies.
+
+## What are CocoaPods Specs?
+
+CocoaPods specs are metadata files (written in Ruby) that describe how to download, build, and integrate iOS libraries. This repository acts as a catalog that CocoaPods queries when resolving dependencies.
+
+## Using This Specs Repository
+
+### In Your Podfile
+
+Add this repository as a source in your `Podfile`:
+
+```ruby
+source 'https://cdn.cocoapods.org/'  # Official CocoaPods specs
+source 'https://github.com/forcedotcom/SalesforceMobileSDK-iOS-Specs.git'  # Salesforce SDK specs
+
+target 'MyApp' do
+  use_frameworks!
+
+  # iOS SDK libraries
+  pod 'MobileSync', '~> 13.2.0'
+  pod 'SmartStore', '~> 13.2.0'
+  pod 'SalesforceSDKCore', '~> 13.2.0'
+
+  # Or for hybrid apps
+  pod 'SalesforceHybridSDK', '~> 13.2.0'
+
+  # Or for React Native
+  pod 'SalesforceReact', '~> 13.2.0'
+end
+```
+
+### Install Dependencies
+
+```bash
+pod install
+```
+
+CocoaPods will:
+1. Clone this specs repository
+2. Find the requested library versions
+3. Download the SDK from GitHub
+4. Integrate it into your Xcode project
+
+## Available Libraries
+
+All Salesforce Mobile SDK libraries for iOS are available through this specs repository:
+
+| Library | Description |
+|---------|-------------|
+| **SalesforceSDKCommon** | Shared utilities, crypto, and base protocols |
+| **SalesforceAnalytics** | Telemetry and event tracking |
+| **SalesforceSDKCore** | OAuth, REST API, account management, push notifications |
+| **SmartStore** | Encrypted SQLite storage with SQLCipher |
+| **MobileSync** | Data synchronization framework |
+| **SalesforceHybridSDK** | Cordova hybrid app support |
+| **SalesforceReact** | React Native bridge |
+| **SalesforceFileLogger** | File-based logging |
+| **AgentforceSDK** | Agentforce agent functionality |
+| **SalesforceSwiftSDK** | Modern Swift SDK layer |
+
+## Repository Structure
+
+Podspecs are organized by library name and version:
+
+```
+SalesforceMobileSDK-iOS-Specs/
+├── MobileSync/
+│   ├── 13.2.0/
+│   │   └── MobileSync.podspec
+│   ├── 13.1.0/
+│   │   └── MobileSync.podspec
+│   └── ...
+│
+├── SmartStore/
+│   ├── 13.2.0/
+│   │   └── SmartStore.podspec
+│   └── ...
+│
+└── (other libraries follow same pattern)
+```
+
+## Version Compatibility
+
+All SDK libraries share the same version number for each release:
+
+| SDK Version | iOS Min | Xcode | Release Date |
+|------------|---------|-------|--------------|
+| 13.2.0     | 17.0    | 15+   | Latest       |
+| 13.1.0     | 16.0    | 15+   | -            |
+| 13.0.0     | 16.0    | 15+   | -            |
+
+See [release notes](https://github.com/forcedotcom/SalesforceMobileSDK-iOS/releases) for detailed version history.
+
+## For SDK Developers
+
+### Publishing New Versions
+
+If you're a maintainer publishing a new SDK version:
+
+1. **Prepare iOS Repo**: Update and tag `SalesforceMobileSDK-iOS`
+2. **Update Specs**: Run the update script in this repo:
+   ```bash
+   ./update.sh -b v13.2.0 -v 13.2.0
+   ```
+3. **Validate**: Lint podspecs before committing:
+   ```bash
+   pod spec lint MobileSync/13.2.0/MobileSync.podspec \
+     --sources='https://github.com/forcedotcom/SalesforceMobileSDK-iOS-Specs.git,https://cdn.cocoapods.org/'
+   ```
+4. **Commit and Push**:
+   ```bash
+   git add .
+   git commit -m "Release v13.2.0"
+   git push origin master
+   ```
+
+### Testing Podspecs Locally
+
+Before publishing, test podspecs locally:
+
+```ruby
+# In your test app's Podfile
+pod 'MobileSync', :podspec => '/path/to/SalesforceMobileSDK-iOS-Specs/MobileSync/13.2.0/MobileSync.podspec'
+```
+
+## Alternative: Swift Package Manager
+
+If you prefer Swift Package Manager over CocoaPods, see the [SalesforceMobileSDK-iOS-SPM](https://github.com/forcedotcom/SalesforceMobileSDK-iOS-SPM) repository.
+
+## Documentation
+
+- **Mobile SDK Developer Guide**: https://developer.salesforce.com/docs/platform/mobile-sdk/guide
+- **iOS SDK Documentation**: https://forcedotcom.github.io/SalesforceMobileSDK-iOS
+- **CocoaPods Guides**: https://guides.cocoapods.org/
+- **Podspec Syntax**: https://guides.cocoapods.org/syntax/podspec.html
+
+## Related Repositories
+
+- **iOS SDK** (source code): https://github.com/forcedotcom/SalesforceMobileSDK-iOS
+- **iOS SPM** (Swift Package Manager): https://github.com/forcedotcom/SalesforceMobileSDK-iOS-SPM
+- **iOS Hybrid**: https://github.com/forcedotcom/SalesforceMobileSDK-iOS-Hybrid
+- **Templates**: https://github.com/forcedotcom/SalesforceMobileSDK-Templates
+
+## Support
+
+- **Issues**: [GitHub Issues](https://github.com/forcedotcom/SalesforceMobileSDK-iOS-Specs/issues)
+- **Questions**: [Salesforce Stack Exchange](https://salesforce.stackexchange.com/questions/tagged/mobilesdk)
+- **Community**: [Trailblazer Community](https://trailhead.salesforce.com/trailblazer-community/groups/0F94S000000kH0HSAU)
+
+## License
+
+Salesforce Mobile SDK License. See [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
- Add comprehensive CLAUDE.md explaining role as CocoaPods specs repository
- Document how CocoaPods uses this repo to resolve dependencies
- Document update.sh script for copying podspecs from iOS repo
- Enhance README.md with usage examples, library descriptions, and version compatibility
- Include podspec validation instructions and release process
- Add publisher guidelines for SDK maintainers