### PR TITLE
Add SocketRocket 0.7.1 podspec

### DIFF
--- a/SocketRocket/0.7.1/SocketRocket.podspec
+++ b/SocketRocket/0.7.1/SocketRocket.podspec
@@ -1,0 +1,23 @@
+Pod::Spec.new do |s|
+  s.name               = 'SocketRocket'
+  s.version            = '0.7.1'
+  s.summary            = 'A conforming WebSocket (RFC 6455) client library for iOS, macOS and tvOS.'
+  s.homepage           = 'https://github.com/facebook/SocketRocket'
+  s.authors            = { 'Nikita Lutsenko' => 'nlutsenko@me.com', 'Dan Federman' => 'federman@squareup.com', 'Mike Lewis' => 'mikelikespie@gmail.com' }
+  s.license            = 'BSD'
+  s.source             = { :git => 'https://github.com/facebookincubator/SocketRocket.git', :tag => s.version.to_s }
+  s.requires_arc       = true
+
+  s.source_files       = 'SocketRocket/**/*.{h,m}'
+  s.public_header_files = 'SocketRocket/*.h'
+
+  s.ios.deployment_target  = '11.0'
+  s.osx.deployment_target  = '10.13'
+  s.tvos.deployment_target = '11.0'
+  s.visionos.deployment_target = '1.0'
+
+  s.ios.frameworks     = 'CFNetwork', 'Security'
+  s.osx.frameworks     = 'CoreServices', 'Security'
+  s.tvos.frameworks    = 'CFNetwork', 'Security'
+  s.libraries          = 'icucore'
+end


### PR DESCRIPTION
## Summary
- SocketRocket was removed from the CocoaPods trunk/CDN, causing all React Native template builds to fail with: `Unable to find a specification for 'SocketRocket (~> 0.7.1)'`
- React Native 0.81+ depends on `SocketRocket ~> 0.7.1` for WebSocket support
- Hosts the podspec here so Mobile SDK React Native templates can resolve the dependency via the Salesforce specs source
- The podspec is identical to the one in `facebookincubator/SocketRocket` at tag `0.7.1`

## Test plan
- [ ] Verify `pod install` succeeds for ReactNativeTypeScriptTemplate with this spec source
- [ ] Verify SalesforceMobileSDK-Templates nightly CI passes (iOS RN templates)
- [ ] Verify SalesforceMobileSDK-Package nightly CI passes (forcereact-ios jobs)